### PR TITLE
Rate Limiting

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,8 +93,7 @@ func fetchRelationships(token string) (map[UserID][]UserID, []Relationship, erro
 					//log.Println("Rate Limit:", time.Millisecond*time.Duration(rateLimit.RetryAfter*1000)+backOff)
 
 					backOff += time.Millisecond * 100
-					limit := time.Millisecond * time.Duration(rateLimit.RetryAfter*1000)
-					limit += backOff
+					limit := time.Millisecond*time.Duration(rateLimit.RetryAfter*1000) + backOff
 					time.Sleep(limit)
 					continue
 				}


### PR DESCRIPTION
I put the whole block in a for loop so that if a request gets rate limited, it can just sleep and then try the same request again as to not skip a relationship, and if successful, it breaks back to the main loop for the next relationship.
It adds 100ms each time it gets rate limited.